### PR TITLE
feat: #38 signUp 페이지 UI 구현

### DIFF
--- a/src/app/Router.jsx
+++ b/src/app/Router.jsx
@@ -2,9 +2,10 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import RootLayout from '@layouts/RootLayout';
 import HomePage from '@pages/HomePage';
 import ViewPage from '@pages/view/ViewPage';
-import SigninPage from '@pages/sign-in/SignInPage';
 import WritePage from '@pages/write/WritePage';
 import MyPage from '@/pages/MyPage';
+import SignInPage from '@pages/sign-in/SignInPage';
+import SignUpPage from '@pages/sign-in/SignInPage';
 
 const publicRoutes = [
   {
@@ -31,7 +32,11 @@ const publicRoutes = [
   },
   {
     path: '/sign-in',
-    element: <SigninPage />
+    element: <SignInPage />
+  },
+  {
+    path: '/sign-up',
+    element: <SignUpPage />
   }
 ];
 

--- a/src/app/Router.jsx
+++ b/src/app/Router.jsx
@@ -1,10 +1,10 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import RootLayout from '@layouts/RootLayout';
 import HomePage from '@pages/HomePage';
-import SigninPage from '@pages/sign-in/SignInPage';
+import SignInPage from '@pages/sign-in/SignInPage';
 import WritePage from '@pages/write/WritePage';
 import MyPage from '@/pages/MyPage';
-
+import SignUpPage from '@/pages/sign-up/SignUpPage';
 
 const publicRoutes = [
   {
@@ -27,7 +27,11 @@ const publicRoutes = [
   },
   {
     path: '/sign-in',
-    element: <SigninPage />
+    element: <SignInPage />
+  },
+  {
+    path: '/sign-up',
+    element: <SignUpPage />
   }
 ];
 

--- a/src/app/Router.jsx
+++ b/src/app/Router.jsx
@@ -5,7 +5,7 @@ import ViewPage from '@pages/view/ViewPage';
 import WritePage from '@pages/write/WritePage';
 import MyPage from '@/pages/MyPage';
 import SignInPage from '@pages/sign-in/SignInPage';
-import SignUpPage from '@pages/sign-in/SignInPage';
+import SignUpPage from '@/pages/sign-up/SignUpPage';
 
 const publicRoutes = [
   {

--- a/src/components/commons/Input.jsx
+++ b/src/components/commons/Input.jsx
@@ -13,7 +13,7 @@ export default function Input({ icon: Icon, width, ...props }) {
 const StInputContainer = styled.div`
   display: flex;
   align-items: center;
-  border: 2px solid var(--color-border);
+  border: 1px solid var(--color-border);
   border-radius: var(--round-md);
   padding: 4px 8px;
   width: ${(props) => props.width || '100%'};

--- a/src/pages/sign-in/SignInPage.jsx
+++ b/src/pages/sign-in/SignInPage.jsx
@@ -45,7 +45,9 @@ export default function SigninPage() {
           <MdDoneOutline />
           로그인
         </StSignInButton>
-        <Link to="/"> 회원가입이 아직인가요? </Link>
+        <Link to="/signUp" className="sign-in-link">
+          회원가입이 아직인가요?
+        </Link>
       </StSignInForm>
     </StContainer>
   );
@@ -56,10 +58,12 @@ const StContainer = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  position: relative;
+  top: var(--height-sm);
   width: 700px;
   height: 880px;
   margin: 0 auto;
-  border: 2px solid var(--color-border);
+  border: 1px solid var(--color-point);
 
   > img {
     width: 400px;
@@ -74,6 +78,9 @@ const StSignInForm = styled.form`
   flex-direction: column;
   margin: 50px;
   height: 400px;
+  .sign-in-link {
+    color: var(--color-point-dark);
+  }
 `;
 
 const StErrorMessage = styled.p`

--- a/src/pages/sign-in/SignInPage.jsx
+++ b/src/pages/sign-in/SignInPage.jsx
@@ -2,12 +2,11 @@ import styled from 'styled-components';
 import { MdEmail, MdOutlinePrivateConnectivity, MdDoneOutline } from 'react-icons/md';
 import Button from '@commons/Button';
 import Input from '@commons/Input';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import useSignInForm from '@/hooks/auth/useSignInForm';
 
 export default function SigninPage() {
   const { signInState, signInErrorMessage, SignInChangeHandler, signInSubmitHandler } = useSignInForm();
-  const navigate = useNavigate();
   return (
     <StContainer>
       <Link to="/">
@@ -48,9 +47,7 @@ export default function SigninPage() {
           <MdDoneOutline />
           로그인
         </StSignInButton>
-        <Link to="/sign-up" className="sign-in-link">
-          회원가입이 아직인가요?
-        </Link>
+        <Link to="/sign-up">회원가입이 아직인가요?</Link>
       </StSignInForm>
     </StContainer>
   );
@@ -75,7 +72,7 @@ const StSignInForm = styled.form`
   flex-direction: column;
   margin: 50px;
   height: 400px;
-  .sign-in-link {
+  > a {
     color: var(--color-point-dark);
   }
 `;

--- a/src/pages/sign-in/SignInPage.jsx
+++ b/src/pages/sign-in/SignInPage.jsx
@@ -2,14 +2,15 @@ import styled from 'styled-components';
 import { MdEmail, MdOutlinePrivateConnectivity, MdDoneOutline } from 'react-icons/md';
 import Button from '@commons/Button';
 import Input from '@commons/Input';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import useSignInForm from '@/hooks/auth/useSignInForm';
 
 export default function SigninPage() {
   const { signInState, signInErrorMessage, SignInChangeHandler, signInSubmitHandler } = useSignInForm();
+  const navigate = useNavigate();
   return (
     <StContainer>
-      <img src="/image/logo.png" />
+      <img src="/image/logo.png" onClick={() => navigate('/')} />
       <StSignInForm onSubmit={signInSubmitHandler}>
         <StErrorMessage $show={!!signInErrorMessage}>{signInErrorMessage || ''}</StErrorMessage>
 

--- a/src/pages/sign-in/SignInPage.jsx
+++ b/src/pages/sign-in/SignInPage.jsx
@@ -10,7 +10,9 @@ export default function SigninPage() {
   const navigate = useNavigate();
   return (
     <StContainer>
-      <img src="/image/logo.png" onClick={() => navigate('/')} />
+      <Link to="/">
+        <StImg src="/image/logo.png" />
+      </Link>
       <StSignInForm onSubmit={signInSubmitHandler}>
         <StErrorMessage $show={!!signInErrorMessage}>{signInErrorMessage || ''}</StErrorMessage>
 
@@ -46,7 +48,7 @@ export default function SigninPage() {
           <MdDoneOutline />
           로그인
         </StSignInButton>
-        <Link to="/signUp" className="sign-in-link">
+        <Link to="/sign-up" className="sign-in-link">
           회원가입이 아직인가요?
         </Link>
       </StSignInForm>
@@ -65,13 +67,7 @@ const StContainer = styled.div`
   height: 880px;
   margin: 0 auto;
   border: 1px solid var(--color-point);
-
-  > img {
-    width: 400px;
-    height: 280px;
-  }
 `;
-
 const StSignInForm = styled.form`
   display: flex;
   justify-content: space-evenly;
@@ -92,6 +88,13 @@ const StErrorMessage = styled.p`
   visibility: ${(show) => (show ? 'visible' : 'hidden')};
 `;
 
+const StImg = styled.img`
+  width: 400px;
+  height: 280px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
 const StSignInButton = styled(Button)`
   text-align: center;
   line-height: normal;

--- a/src/pages/sign-up/SignUpInput.jsx
+++ b/src/pages/sign-up/SignUpInput.jsx
@@ -1,11 +1,11 @@
-import Input from '@/components/commons/Input';
+import Input from '@commons/Input';
 import styled from 'styled-components';
 
 export default function SignUpInput({ labelName, inputType, ...props }) {
   return (
     <StSignUpInput>
       <label>{labelName}: </label>
-      <Input type={inputType} {...props} required />
+      <Input type={inputType} {...props} width="374px" required />
     </StSignUpInput>
   );
 }
@@ -16,7 +16,7 @@ const StSignUpInput = styled.div`
   align-items: start;
   flex-direction: column;
   margin-bottom: 8px;
-  width: 394px;
+  width: 392px;
   & > label {
     margin-bottom: 4px;
   }

--- a/src/pages/sign-up/SignUpInput.jsx
+++ b/src/pages/sign-up/SignUpInput.jsx
@@ -1,11 +1,11 @@
 import Input from '@/components/commons/Input';
 import styled from 'styled-components';
 
-export default function SignUpInput({ labelName, name, inputType, placeholder, inputWidth, iconImage }) {
+export default function SignUpInput({ labelName, inputType, ...props }) {
   return (
     <StSignUpInput>
       <label>{labelName}: </label>
-      <Input name={name} type={inputType} placeholder={placeholder} width={inputWidth} icon={iconImage} required />
+      <Input type={inputType} {...props} required />
     </StSignUpInput>
   );
 }

--- a/src/pages/sign-up/SignUpInput.jsx
+++ b/src/pages/sign-up/SignUpInput.jsx
@@ -1,0 +1,23 @@
+import Input from '@/components/commons/Input';
+import styled from 'styled-components';
+
+export default function SignUpInput({ labelName, name, inputType, placeholder, inputWidth, iconImage }) {
+  return (
+    <StSignUpInput>
+      <label>{labelName}: </label>
+      <Input name={name} type={inputType} placeholder={placeholder} width={inputWidth} icon={iconImage} required />
+    </StSignUpInput>
+  );
+}
+
+const StSignUpInput = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: start;
+  flex-direction: column;
+  margin-bottom: 8px;
+  width: 394px;
+  & > label {
+    margin-bottom: 4px;
+  }
+`;

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -1,5 +1,5 @@
 import Button from '@/components/commons/Button';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   MdDoneOutline,
   MdEmail,
@@ -10,25 +10,20 @@ import {
 import styled from 'styled-components';
 import SignUpInput from './SignUpInput';
 import SelectBox from '@/components/commons/SelectBox';
-import { useState } from 'react';
 import Input from '@/components/commons/Input';
-import useSignUpForm from '@/hooks/auth/useSignUpForm';
 
 export default function SignUpPage() {
-  const navigate = useNavigate();
-  const inputWidth = '374px';
-
   return (
     <StContainer>
-      <img src="/image/logo.png" onClick={() => navigate('/')} />
+      <Link to="/">
+        <StImg src="/image/logo.png" />
+      </Link>
       <StSignUpForm>
         <StEmailNickNameWrapper>
           <label>아이디: </label>
           <div>
             <Input name="email" type="text" placeholder="이메일을 입력해주세요" width="280px" icon={MdEmail} required />
-            <StDuplicateButton $color="point" $size="lg" $round="md">
-              중복체크
-            </StDuplicateButton>
+            <StDuplicateButton>중복체크</StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
 
@@ -37,7 +32,6 @@ export default function SignUpPage() {
           name="password"
           inputType="password"
           placeholder="비밀번호를 입력해주세요"
-          $inputWidth={inputWidth}
           $iconImage={MdOutlinePrivateConnectivity}
         />
 
@@ -45,7 +39,6 @@ export default function SignUpPage() {
           labelName="비밀번호 확인"
           inputType="password"
           placeholder="비밀번호를 다시 입력해주세요"
-          $inputWidth={inputWidth}
           $iconImage={MdOutlinePrivateConnectivity}
         />
 
@@ -60,9 +53,7 @@ export default function SignUpPage() {
               icon={MdOutlinePersonOutline}
               required
             />
-            <StDuplicateButton $color="point" $size="lg" $round="md">
-              중복체크
-            </StDuplicateButton>
+            <StDuplicateButton>중복체크</StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
 
@@ -86,31 +77,20 @@ export default function SignUpPage() {
           name="answer"
           inputType="text"
           placeholder="질문에 대한 답을 입력해주세요"
-          $inputWidth={inputWidth}
           $iconImage={MdOutlineChat}
         />
 
-        <StSignUpButton type="submit" $color="point" $size="lg" $round="lg">
+        <StSignUpButton type="submit">
           <MdDoneOutline />
           회원가입
         </StSignUpButton>
-        <Link to="/signIn" className="custom-link">
+        <Link to="/sign-in" className="custom-link">
           이미 회원가입을 하셨나요?
         </Link>
       </StSignUpForm>
     </StContainer>
   );
 }
-
-const StSelectWrapper = styled.div`
-  width: 394px;
-  height: 64px;
-  margin-bottom: 8px;
-  & > label {
-    display: block;
-    margin-bottom: 4px;
-  }
-`;
 
 const StContainer = styled.div`
   display: flex;
@@ -122,15 +102,7 @@ const StContainer = styled.div`
   height: 880px;
   margin: 0 auto;
   border: 1px solid var(--color-point);
-  > img {
-    width: 300px;
-    height: 200px;
-    &:hover {
-      cursor: pointer;
-    }
-  }
 `;
-
 const StSignUpForm = styled.form`
   display: flex;
   justify-content: center;
@@ -142,30 +114,15 @@ const StSignUpForm = styled.form`
   }
 `;
 
-const StSignUpButton = styled(Button)`
-  text-align: center;
-  line-height: normal;
-  width: 394px;
-  height: 80px;
-  font-size: var(--font-size-lg);
-  margin: var(--height-sm) 0px;
-  & > svg {
-    font-size: 32px;
-    position: relative;
-    left: -var(--font-size-lg);
+const StSelectWrapper = styled.div`
+  width: 392px;
+  height: 64px;
+  margin-bottom: 8px;
+  & > label {
+    display: block;
+    margin-bottom: 4px;
   }
 `;
-
-const StDuplicateButton = styled(Button)`
-  text-align: center;
-  line-height: normal;
-  width: 84px;
-  height: 44px;
-  font-size: var(--font-size-sm);
-  margin-left: 10px;
-  padding: 4px 8px;
-`;
-
 const StEmailNickNameWrapper = styled.div`
   margin-bottom: 8px;
   > div {
@@ -178,4 +135,34 @@ const StEmailNickNameWrapper = styled.div`
     display: block;
     margin-bottom: 4px;
   }
+`;
+
+const StImg = styled.img`
+  width: 300px;
+  height: 200px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+const StSignUpButton = styled(Button).attrs({ $color: 'point', $size: 'lg', $round: 'lg' })`
+  text-align: center;
+  line-height: normal;
+  width: 392px;
+  height: 80px;
+  font-size: var(--font-size-lg);
+  margin: var(--height-sm) 0px;
+  & > svg {
+    font-size: 32px;
+    position: relative;
+    left: -var(--font-size-lg);
+  }
+`;
+const StDuplicateButton = styled(Button).attrs({ $color: 'point', $size: 'lg', $round: 'md' })`
+  text-align: center;
+  line-height: normal;
+  width: 84px;
+  height: 44px;
+  font-size: var(--font-size-sm);
+  margin-left: 10px;
+  padding: 4px 8px;
 `;

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -84,9 +84,7 @@ export default function SignUpPage() {
           <MdDoneOutline />
           회원가입
         </StSignUpButton>
-        <Link to="/sign-in" className="custom-link">
-          이미 회원가입을 하셨나요?
-        </Link>
+        <Link to="/sign-in">이미 회원가입을 하셨나요?</Link>
       </StSignUpForm>
     </StContainer>
   );
@@ -109,7 +107,7 @@ const StSignUpForm = styled.form`
   align-items: center;
   flex-direction: column;
   margin: 50px;
-  .custom-link {
+  > a {
     color: var(--color-point-dark);
   }
 `;

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -12,9 +12,9 @@ import SignUpInput from './SignUpInput';
 import SelectBox from '@/components/commons/SelectBox';
 import { useState } from 'react';
 import Input from '@/components/commons/Input';
+import useSignUpForm from '@/hooks/auth/useSignUpForm';
 
 export default function SignUpPage() {
-  const [question, setQuestion] = useState('');
   const navigate = useNavigate();
   const inputWidth = '374px';
 
@@ -26,41 +26,42 @@ export default function SignUpPage() {
           <label>아이디: </label>
           <div>
             <Input name="email" type="text" placeholder="이메일을 입력해주세요" width="280px" icon={MdEmail} required />
-            <StDuplicateButton type="submit" $color="point" $size="lg" $round="md">
-              아이디 중복체크
+            <StDuplicateButton $color="point" $size="lg" $round="md">
+              중복체크
             </StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
 
         <SignUpInput
           labelName="비밀번호"
+          name="password"
           inputType="password"
           placeholder="비밀번호를 입력해주세요"
-          inputWidth={inputWidth}
-          iconImage={MdOutlinePrivateConnectivity}
+          $inputWidth={inputWidth}
+          $iconImage={MdOutlinePrivateConnectivity}
         />
 
         <SignUpInput
           labelName="비밀번호 확인"
-          inputType="text"
+          inputType="password"
           placeholder="비밀번호를 다시 입력해주세요"
-          inputWidth={inputWidth}
-          iconImage={MdOutlinePrivateConnectivity}
+          $inputWidth={inputWidth}
+          $iconImage={MdOutlinePrivateConnectivity}
         />
 
         <StEmailNickNameWrapper>
           <label>닉네임: </label>
           <div>
             <Input
-              name="nickName"
+              name="nickname"
               type="text"
               placeholder="닉네임을 입력해주세요"
               width="280px"
               icon={MdOutlinePersonOutline}
               required
             />
-            <StDuplicateButton type="submit" $color="point" $size="lg" $round="md">
-              닉네임 중복체크
+            <StDuplicateButton $color="point" $size="lg" $round="md">
+              중복체크
             </StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
@@ -68,8 +69,6 @@ export default function SignUpPage() {
         <StSelectWrapper>
           <label>질문: </label>
           <SelectBox
-            value={question}
-            onChange={setQuestion} // 선택 시 input 값 변경
             options={[
               { id: 0, name: '내 보물 1호는?' },
               { id: 1, name: '내가 졸업한 초등학교는?' },
@@ -84,17 +83,17 @@ export default function SignUpPage() {
 
         <SignUpInput
           labelName="질문 응답"
+          name="answer"
           inputType="text"
           placeholder="질문에 대한 답을 입력해주세요"
-          inputWidth={inputWidth}
-          iconImage={MdOutlineChat}
+          $inputWidth={inputWidth}
+          $iconImage={MdOutlineChat}
         />
 
         <StSignUpButton type="submit" $color="point" $size="lg" $round="lg">
           <MdDoneOutline />
           회원가입
         </StSignUpButton>
-
         <Link to="/signIn" className="custom-link">
           이미 회원가입을 하셨나요?
         </Link>

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -1,5 +1,5 @@
 import Button from '@/components/commons/Button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   MdDoneOutline,
   MdEmail,
@@ -15,11 +15,12 @@ import Input from '@/components/commons/Input';
 
 export default function SignUpPage() {
   const [question, setQuestion] = useState('');
+  const navigate = useNavigate();
   const inputWidth = '374px';
 
   return (
     <StContainer>
-      <img src="/image/logo.png" />
+      <img src="/image/logo.png" onClick={() => navigate('/')} />
       <StSignUpForm>
         <StEmailNickNameWrapper>
           <label>아이디: </label>
@@ -55,7 +56,7 @@ export default function SignUpPage() {
               type="text"
               placeholder="닉네임을 입력해주세요"
               width="280px"
-              icon={MdEmail}
+              icon={MdOutlinePersonOutline}
               required
             />
             <StDuplicateButton type="submit" $color="point" $size="lg" $round="md">
@@ -125,6 +126,9 @@ const StContainer = styled.div`
   > img {
     width: 300px;
     height: 200px;
+    &:hover {
+      cursor: pointer;
+    }
   }
 `;
 

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -1,0 +1,174 @@
+import Button from '@/components/commons/Button';
+import { Link } from 'react-router-dom';
+import {
+  MdDoneOutline,
+  MdEmail,
+  MdOutlineChat,
+  MdOutlinePersonOutline,
+  MdOutlinePrivateConnectivity
+} from 'react-icons/md';
+import styled from 'styled-components';
+import SignUpInput from './SignUpInput';
+import SelectBox from '@/components/commons/SelectBox';
+import { useState } from 'react';
+import Input from '@/components/commons/Input';
+
+export default function SignUpPage() {
+  const [question, setQuestion] = useState('');
+  const inputWidth = '374px';
+
+  return (
+    <StContainer>
+      <img src="/image/logo.png" />
+      <StSignUpForm>
+        <StEmailNickNameWrapper>
+          <label>아이디: </label>
+          <div>
+            <Input name="email" type="text" placeholder="이메일을 입력해주세요" width="280px" icon={MdEmail} required />
+            <StDuplicateButton>아이디 중복체크</StDuplicateButton>
+          </div>
+        </StEmailNickNameWrapper>
+
+        <SignUpInput
+          labelName="비밀번호"
+          inputType="password"
+          placeholder="비밀번호를 입력해주세요"
+          inputWidth={inputWidth}
+          iconImage={MdOutlinePrivateConnectivity}
+        />
+
+        <SignUpInput
+          labelName="비밀번호 확인"
+          inputType="text"
+          placeholder="비밀번호를 다시 입력해주세요"
+          inputWidth={inputWidth}
+          iconImage={MdOutlinePrivateConnectivity}
+        />
+
+        <StEmailNickNameWrapper>
+          <label>닉네임: </label>
+          <div>
+            <Input
+              name="nickName"
+              type="text"
+              placeholder="닉네임을 입력해주세요"
+              width="280px"
+              icon={MdEmail}
+              required
+            />
+            <StDuplicateButton>닉네임 중복체크</StDuplicateButton>
+          </div>
+        </StEmailNickNameWrapper>
+
+        <StSelectWrapper>
+          <label>질문: </label>
+          <SelectBox
+            value={question}
+            onChange={setQuestion} // 선택 시 input 값 변경
+            options={[
+              { id: 0, name: '내 보물 1호는?' },
+              { id: 1, name: '내가 졸업한 초등학교는?' },
+              { id: 2, name: '내가 졸업한 중학교는?' },
+              { id: 3, name: '내가 졸업한 고등학교는?' },
+              { id: 4, name: '우리집 가훈은?' },
+              { id: 5, name: '우리집 반려동물 이름은?' }
+            ]}
+            size="sm"
+          />
+        </StSelectWrapper>
+
+        <SignUpInput
+          labelName="질문 응답"
+          inputType="text"
+          placeholder="질문에 대한 답을 입력해주세요"
+          inputWidth={inputWidth}
+          iconImage={MdOutlineChat}
+        />
+
+        <StSignUpButton type="submit" $color="point" $size="lg" $round="lg">
+          <MdDoneOutline />
+          회원가입
+        </StSignUpButton>
+
+        <Link to="/signIn" className="custom-link">
+          이미 회원가입을 하셨나요?
+        </Link>
+      </StSignUpForm>
+    </StContainer>
+  );
+}
+
+const StSelectWrapper = styled.div`
+  width: 394px;
+  height: 64px;
+  margin-bottom: 8px;
+  & > label {
+    display: block;
+    margin-bottom: 4px;
+  }
+`;
+
+const StContainer = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  position: relative;
+  top: var(--height-sm);
+  width: 700px;
+  height: 880px;
+  margin: 0 auto;
+  border: 1px solid var(--color-point);
+  > img {
+    width: 300px;
+    height: 200px;
+  }
+`;
+
+const StSignUpForm = styled.form`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin: 50px;
+  .custom-link {
+    color: var(--color-point-dark);
+  }
+`;
+
+const StSignUpButton = styled(Button)`
+  text-align: center;
+  line-height: normal;
+  width: 394px;
+  height: 80px;
+  font-size: var(--font-size-lg);
+  margin: var(--height-sm) 0px;
+  & > svg {
+    font-size: 32px;
+    position: relative;
+    left: -var(--font-size-lg);
+  }
+`;
+
+const StDuplicateButton = styled(Button)`
+  text-align: center;
+  line-height: normal;
+  padding: 4px 8px;
+  height: 44px;
+  width: 84px;
+  font-size: var(--font-size-sm);
+  margin-left: 10px;
+`;
+
+const StEmailNickNameWrapper = styled.div`
+  margin-bottom: 8px;
+  > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+  }
+  > label {
+    display: block;
+    margin-bottom: 4px;
+  }
+`;

--- a/src/pages/sign-up/SignUpPage.jsx
+++ b/src/pages/sign-up/SignUpPage.jsx
@@ -25,7 +25,9 @@ export default function SignUpPage() {
           <label>아이디: </label>
           <div>
             <Input name="email" type="text" placeholder="이메일을 입력해주세요" width="280px" icon={MdEmail} required />
-            <StDuplicateButton>아이디 중복체크</StDuplicateButton>
+            <StDuplicateButton type="submit" $color="point" $size="lg" $round="md">
+              아이디 중복체크
+            </StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
 
@@ -56,7 +58,9 @@ export default function SignUpPage() {
               icon={MdEmail}
               required
             />
-            <StDuplicateButton>닉네임 중복체크</StDuplicateButton>
+            <StDuplicateButton type="submit" $color="point" $size="lg" $round="md">
+              닉네임 중복체크
+            </StDuplicateButton>
           </div>
         </StEmailNickNameWrapper>
 
@@ -152,11 +156,11 @@ const StSignUpButton = styled(Button)`
 const StDuplicateButton = styled(Button)`
   text-align: center;
   line-height: normal;
-  padding: 4px 8px;
-  height: 44px;
   width: 84px;
+  height: 44px;
   font-size: var(--font-size-sm);
   margin-left: 10px;
+  padding: 4px 8px;
 `;
 
 const StEmailNickNameWrapper = styled.div`


### PR DESCRIPTION
## 💡 관련이슈
> #38 

## 🍀 작업 요약
- 회원 가입 페이지 UI 구현

## 💬 리뷰 요구 사항
> 의논하고 싶은 내용이 있다면 작성해주세요.
> 리뷰 예상 시간: 8분
- 화면의 통일성을 위해서 컴포넌트를 작성했는데 너무 난잡한거 같습니다!
- 중복 버튼이 필요한 부분과 통일성을 주기위해 width를 직접 설정한 부분이 많은데 해결방법이나 좋은 방법있으면 알려주시면 감사하겠습니다!
- 비밀번호 찾기 질문을 피그마처럼 만드는 방법을 도저히 적용을 못시켜서 selectBox로 만들었습니다.

## 💛 미리보기

![캡처](https://github.com/user-attachments/assets/ec9a0cb6-56ba-41b5-9bde-05bf77e0015d)

